### PR TITLE
Logs for error analyses

### DIFF
--- a/sts-keymanagement/sts-keymanagement-impl/src/main/java/de/adorsys/sts/keymanagement/persistence/CachedKeyStoreRepository.java
+++ b/sts-keymanagement/sts-keymanagement-impl/src/main/java/de/adorsys/sts/keymanagement/persistence/CachedKeyStoreRepository.java
@@ -1,9 +1,11 @@
 package de.adorsys.sts.keymanagement.persistence;
 
 import de.adorsys.sts.keymanagement.model.StsKeyStore;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.ZonedDateTime;
 
+@Slf4j
 public class CachedKeyStoreRepository implements KeyStoreRepository {
 
     private final KeyStoreRepository keyStoreRepository;
@@ -15,33 +17,49 @@ public class CachedKeyStoreRepository implements KeyStoreRepository {
 
     @Override
     public StsKeyStore load() {
-        if(cachedKeyStore == null) {
+        log.debug("Calling load(). Cached key store last update: {}", cachedKeyStore != null ? cachedKeyStore.getLastUpdate() : null);
+
+        if (cachedKeyStore == null) {
+            log.debug("Cache is null, loading from repository");
             cachedKeyStore = keyStoreRepository.load();
         } else {
             ZonedDateTime lastUpdate = keyStoreRepository.lastUpdate();
             ZonedDateTime cachedLastUpdate = cachedKeyStore.getLastUpdate();
 
-            if(lastUpdate.isAfter(cachedLastUpdate)) {
+            if (lastUpdate.isAfter(cachedLastUpdate)) {
+                log.debug("Repository was updated more recently than cache. Refreshing cache.");
                 cachedKeyStore = keyStoreRepository.load();
             }
         }
 
+        log.debug("Returning cached key store with last update: {}", cachedKeyStore != null ? cachedKeyStore.getLastUpdate() : null);
         return cachedKeyStore;
     }
 
     @Override
     public boolean exists() {
-        return cachedKeyStore != null || keyStoreRepository.exists();
+        boolean exists = cachedKeyStore != null || keyStoreRepository.exists();
+
+        log.debug("Checking if KeyStore exists. Result: {}", exists);
+
+        return exists;
     }
 
     @Override
     public void save(StsKeyStore keyStore) {
+        log.debug("Saving keyStore to repository...");
         keyStoreRepository.save(keyStore);
+
+        log.debug("Updating cache with newly saved keyStore");
         cachedKeyStore = keyStore;
     }
 
     @Override
     public ZonedDateTime lastUpdate() {
-        return keyStoreRepository.lastUpdate();
+        ZonedDateTime lastUpdate = keyStoreRepository.lastUpdate();
+
+        log.debug("LastUpdate: {}", lastUpdate);
+
+        return lastUpdate;
     }
 }

--- a/sts-spring/src/main/java/de/adorsys/sts/keymanagement/KeyManagementConfiguration.java
+++ b/sts-spring/src/main/java/de/adorsys/sts/keymanagement/KeyManagementConfiguration.java
@@ -10,6 +10,7 @@ import de.adorsys.sts.keymanagement.model.StsKeyEntryImpl;
 import de.adorsys.sts.keymanagement.persistence.CachedKeyStoreRepository;
 import de.adorsys.sts.keymanagement.persistence.KeyStoreRepository;
 import de.adorsys.sts.keymanagement.service.*;
+import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,7 @@ import java.time.ZonedDateTime;
                 type = FilterType.REGEX
         )
 )
+@Slf4j
 public class KeyManagementConfiguration {
 
     @Bean
@@ -41,6 +43,7 @@ public class KeyManagementConfiguration {
 
     @Bean(name = "cached")
     KeyStoreRepository cachedKeyStoreRepository(KeyStoreRepository keyStoreRepository) {
+        log.debug("Creating 'cached' KeyStoreRepository bean...");
         return new CachedKeyStoreRepository(keyStoreRepository);
     }
 


### PR DESCRIPTION
Added logs to AuthServer to see if multiple threads try to update the cache at the same time
Added logs to Configuration to anticipate if the server was restarted and therefore cached beans are recreated
Added log to load key repository (especially load-method) to analyse cached behaviour
Added ApplicationEventListener to see shutdowns of the server in the logs