### PR TITLE
Custom sequence generator not batch compatible

### DIFF
--- a/sts-persistence-jpa/src/main/java/de/adorsys/sts/persistence/jpa/entity/JpaKeyEntryAttributes.java
+++ b/sts-persistence-jpa/src/main/java/de/adorsys/sts/persistence/jpa/entity/JpaKeyEntryAttributes.java
@@ -18,8 +18,7 @@ import java.time.ZonedDateTime;
 public class JpaKeyEntryAttributes {
 
     @Id
-    @SequenceGenerator(name = "key_entry_seq", sequenceName = "key_entry_id_seq", allocationSize = 1)
-    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "key_entry_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Long keyStoreId;

--- a/sts-persistence-jpa/src/main/java/de/adorsys/sts/persistence/jpa/entity/JpaKeyStore.java
+++ b/sts-persistence-jpa/src/main/java/de/adorsys/sts/persistence/jpa/entity/JpaKeyStore.java
@@ -14,8 +14,7 @@ import java.time.ZonedDateTime;
 public class JpaKeyStore {
 
     @Id
-    @SequenceGenerator(name = "key_store_seq", sequenceName = "key_store_id_seq", allocationSize = 1)
-    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "key_store_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/sts-persistence-jpa/src/main/java/de/adorsys/sts/persistence/jpa/entity/JpaSecret.java
+++ b/sts-persistence-jpa/src/main/java/de/adorsys/sts/persistence/jpa/entity/JpaSecret.java
@@ -12,8 +12,7 @@ import lombok.Setter;
 public class JpaSecret {
 
     @Id
-    @SequenceGenerator(name = "secret_seq", sequenceName = "secret_id_seq", allocationSize = 1)
-    @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "secret_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String subject;


### PR DESCRIPTION
Regarding:
There is yet another important runtime impact of choosing IDENTITY generation: Hibernate will not be able to JDBC batching for inserts of the entities that use IDENTITY generation. The importance of this depends on the application specific use cases. If the application is not usually creating many new instances of a given type of entity that uses IDENTITY generation, then this is not an important impact since batching would not have been helpful anyway.

The custom sequence generator seems not to work properly and produces duplicate key errors. This might be because of the reason mentioned above. Therefore, the custom sequence generator should be replaced with the build in generator from database