### PR TITLE
Enhance JWT verification logs with detailed claim data

### DIFF
--- a/sts-token-auth/pom.xml
+++ b/sts-token-auth/pom.xml
@@ -13,6 +13,17 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>2.20.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>de.adorsys.sts</groupId>
             <artifactId>sts-common</artifactId>
         </dependency>

--- a/sts-token-auth/src/main/java/de/adorsys/sts/tokenauth/JWTClaimsSetVerifierWithLogs.java
+++ b/sts-token-auth/src/main/java/de/adorsys/sts/tokenauth/JWTClaimsSetVerifierWithLogs.java
@@ -11,9 +11,10 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.util.Date;
+import java.util.Map;
 
 @RequiredArgsConstructor
-public class JWTClaimsSetVerifierWithLogs<C extends SecurityContext>implements JWTClaimsSetVerifier<C> {
+public class JWTClaimsSetVerifierWithLogs<C extends SecurityContext> implements JWTClaimsSetVerifier<C> {
     private final Logger logger = LoggerFactory.getLogger(JWTClaimsSetVerifierWithLogs.class);
 
     /**
@@ -28,9 +29,12 @@ public class JWTClaimsSetVerifierWithLogs<C extends SecurityContext>implements J
 
         final Date exp = claimsSet.getExpirationTime();
 
+        Map<String, Object> claimSet = claimsSet.toPayload().toJSONObject();
+
         if (exp != null && !DateUtils.isAfter(exp, now, DEFAULT_MAX_CLOCK_SKEW_SECONDS)) {
             String msg = "Expired JWT";
-            logger.error(msg);
+            logger.error("{}: expiration time: {} now: {}", msg, exp, now);
+            logger.error("JWT claims: {}", claimSet);
             throw new BadJWTException(msg);
         }
 
@@ -38,7 +42,8 @@ public class JWTClaimsSetVerifierWithLogs<C extends SecurityContext>implements J
 
         if (nbf != null && !DateUtils.isBefore(nbf, now, DEFAULT_MAX_CLOCK_SKEW_SECONDS)) {
             String msg = "JWT before use time";
-            logger.error(msg);
+            logger.error("{}: not before time: {} now: {}", msg, nbf, now);
+            logger.error("JWT claims: {}", claimSet);
             throw new BadJWTException(msg);
         }
     }

--- a/sts-token-auth/src/test/java/de/adorsys/sts/tokenauth/JWTClaimsSetVerifierWithLogsTest.java
+++ b/sts-token-auth/src/test/java/de/adorsys/sts/tokenauth/JWTClaimsSetVerifierWithLogsTest.java
@@ -1,0 +1,57 @@
+package de.adorsys.sts.tokenauth;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JWTClaimsSetVerifierWithLogsTest {
+
+    @org.junit.jupiter.api.Test
+    void verify() {
+        JWTClaimsSetVerifierWithLogs jwtClaimsSetVerifierWithLogs = new JWTClaimsSetVerifierWithLogs(null);
+        assertThrows(NullPointerException.class, () -> jwtClaimsSetVerifierWithLogs.verify(null, null));
+    }
+
+    @Mock
+    private Clock clock;
+
+    private JWTClaimsSetVerifierWithLogs underTest;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        underTest = new JWTClaimsSetVerifierWithLogs(clock);
+    }
+
+    @Test
+    public void testVerify_throwsBadJWTException_whenJWTIsExpired() {
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder().expirationTime(new Date(System.currentTimeMillis() - 60000)).build();
+        when(clock.instant()).thenReturn(Instant.now());
+        assertThrows(BadJWTException.class, () -> {
+            underTest.verify(claimsSet, null);
+        });
+    }
+
+    @Test
+    public void testVerify_throwsBadJWTException_whenJWTIsNotBeforeNow() {
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder().notBeforeTime(new Date(System.currentTimeMillis() + 60000)).build();
+        when(clock.instant()).thenReturn(Instant.now());
+        assertThrows(BadJWTException.class, () -> {
+            underTest.verify(claimsSet, null);
+        });
+    }
+
+}


### PR DESCRIPTION
Added detailed claim data to logs on JWT expiration and not-before time checks. This improves the ability to diagnose issues by providing comprehensive context in error messages.